### PR TITLE
treeWatcher: Split up event fetch to stay under query limit

### DIFF
--- a/src/treeWatcher.js
+++ b/src/treeWatcher.js
@@ -106,8 +106,21 @@ async function init() {
     const miner = await resolver.resolve(torn.miningV2.address)
     contract = new web3.eth.Contract(MinerABI, miner)
     const block = await web3.eth.getBlockNumber()
-    const events = await fetchEvents(0, block)
-    tree = new MerkleTree(minerMerkleTreeHeight, events, { hashFunction: poseidonHash2 })
+
+    // ETH Mainnet problem: There are too many events (about 20k) to get back in the max result set of 10k
+    // Split up requests and combine for MerkleTree build
+    let allevents = []
+    let inc =     100000
+    let rounds = (block / inc) + 1
+    for(let i = 0; i < rounds; i++ ) {
+            console.log('Fetch events ', i * inc, ' to ', (i+1) * inc)
+            const events = await fetchEvents(i * inc, (i + 1) * inc)
+            allevents = [...allevents, ...events]
+            console.log('Received event count: ', events.length)
+    }
+    console.log(`Merkle rebuild tree with ${allevents.length} elements`)
+    tree = new MerkleTree(minerMerkleTreeHeight, allevents, { hashFunction: poseidonHash2 })
+    console.log(`Rebuilt tree with ${allevents.length} elements, root: ${tree.root()}`)
     await updateRedis()
     console.log(`Rebuilt tree with ${events.length} elements, root: ${tree.root()}`)
     eventSubscription = contract.events.NewAccount({ fromBlock: block + 1 }, processNewEvent)


### PR DESCRIPTION
ETH Mainnet Infura Endpoint does not want to provide more than 10000 events per fetch.

This causes treeWatcher to crash.

Split up queries and combine.

Example of error on ETH MainNet

```
treeWatcher_1    | error fetching events Error: Returned error: query returned more than 10000 results
treeWatcher_1    |     at Object.ErrorResponse (/app/node_modules/web3-core-helpers/lib/errors.js:28:19)
treeWatcher_1    |     at Object.callback (/app/node_modules/web3-core-requestmanager/lib/index.js:288:36)
treeWatcher_1    |     at /app/node_modules/web3-providers-ws/lib/index.js:114:45
treeWatcher_1    |     at Array.forEach (<anonymous>)
treeWatcher_1    |     at WebsocketProvider._onMessage (/app/node_modules/web3-providers-ws/lib/index.js:102:69)
treeWatcher_1    |     at W3CWebSocket._dispatchEvent [as dispatchEvent] (/app/node_modules/yaeti/lib/EventTarget.js:115:12)
treeWatcher_1    |     at W3CWebSocket.onMessage (/app/node_modules/websocket/lib/W3CWebSocket.js:234:14)
treeWatcher_1    |     at WebSocketConnection.<anonymous> (/app/node_modules/websocket/lib/W3CWebSocket.js:205:19)
treeWatcher_1    |     at WebSocketConnection.emit (events.js:314:20)
treeWatcher_1    |     at WebSocketConnection.processFrame (/app/node_modules/websocket/lib/WebSocketConnection.js:554:26)
treeWatcher_1    |     at /app/node_modules/websocket/lib/WebSocketConnection.js:323:40
treeWatcher_1    |     at processTicksAndRejections (internal/process/task_queues.js:79:11) {
treeWatcher_1    |   data: null
treeWatcher_1    | }
treeWatcher_1    | Invalid tree root: 18985880316913054223420119281626297509988828082052104176513061368828929683625 != 14103023831951691928177923588846640477836749570015723501250736993514495402372, rebuilding tree
treeWatcher_1    | error Command failed with exit code 1.
```